### PR TITLE
doc(links): links in new tabs

### DIFF
--- a/src/app/index.module.js
+++ b/src/app/index.module.js
@@ -31,7 +31,11 @@ config(['markedProvider', '$locationProvider',
             return "<table class='table'><thead>" + header + "</thead><tbody>"+ body + "</tbody></table>"
         }
     });
-
+    markedProvider.setRenderer({
+        link: function(href, title, text) {
+          return "<a href='" + href + "'" + (title ? " title='" + title + "'" : '') + " target='_blank'>" + text + "</a>";
+        }
+    });
 
     $locationProvider.html5Mode({
         enabled: false,


### PR DESCRIPTION
Links in overview should open in a new tab.

Tests : 
1. `npm start`
2. clic on a link --> it opens in a new tab