### PR TITLE
fix: lookerstudio: key issue in appscript

### DIFF
--- a/bi-tools/lookerstudio/examples/appscript.json
+++ b/bi-tools/lookerstudio/examples/appscript.json
@@ -12,7 +12,7 @@
     "oauthScopes": [
       "https://www.googleapis.com/auth/script.external_request"
     ],
-    "lookerStudio": {
+    "dataStudio": {
       "name": "Lumapps Datalake",
       "logoUrl": "https://avatars.githubusercontent.com/u/2465187?s=200&v=4",
       "company": "Lumapps",


### PR DESCRIPTION
yaml key remains dataStudio despite the product being renamed lookerstudio.
Regression introduced in https://github.com/lumapps/dbt-docs/pull/23